### PR TITLE
:package: Fix MpsTransaction Syntax Error

### DIFF
--- a/lib/Model/MpsTransaction.php
+++ b/lib/Model/MpsTransaction.php
@@ -228,7 +228,7 @@ class MpsTransaction implements ArrayAccess
             $invalid_properties[] = "'mps_payment_type' can't be null";
         }
         $allowed_values = $this->getMpsPaymentTypeAllowableValues();
-        if ($this->container['mps_payment_type'], $allowed_values) {
+        if (!in_array($this->container['mps_payment_type'], $allowed_values)) {
             $invalid_properties[] = sprintf(
                 "invalid value for 'mps_payment_type', must be one of '%s'",
                 implode("', '", $allowed_values)


### PR DESCRIPTION
### Problem
There is a syntax error in MpsTransaction.php, this causes some not so wanted effects.

### Solution 
Add the "missing" part of the code that should actually already be there.